### PR TITLE
Bump Symbolics / SymbolicUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ RecursiveArrayTools = "3"
 SafeTestsets = "0.1"
 StatsBase = "0.34"
 Symbolics = "6"
-SymbolicUtils = "3"
+SymbolicUtils = "3.1.2"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ RecursiveArrayTools = "3"
 SafeTestsets = "0.1"
 StatsBase = "0.34"
 Symbolics = "6"
-SymbolicUtils = "=2.1.1, 3"
+SymbolicUtils = "3"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -33,8 +33,8 @@ PDMats = "0.11"
 RecursiveArrayTools = "3"
 SafeTestsets = "0.1"
 StatsBase = "0.34"
-Symbolics = "5"
-SymbolicUtils = "=2.1.1"
+Symbolics = "6"
+SymbolicUtils = "=2.1.1, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
Why is there a `=2.1.1`? `maketerm` isn't used, so these bumps would be safe based from latest, but that equality there is weird.

Can we get this into the normal orgs so we can assign people to these kinds of issues? Whose issue is this related to, Alessandro's changes?